### PR TITLE
Fixes #73 Use the '=' instead of the space symbol to combine the network inject…

### DIFF
--- a/chaosmeta-inject-operator/pkg/executor/remoteexecutor/daemonsetexecutor/daemonsetexecutor.go
+++ b/chaosmeta-inject-operator/pkg/executor/remoteexecutor/daemonsetexecutor/daemonsetexecutor.go
@@ -103,7 +103,7 @@ func (r *DaemonsetRemoteExecutor) Inject(ctx context.Context, injectObject strin
 		}
 
 		unitArgs.Key = strings.ReplaceAll(unitArgs.Key, "_", "-")
-		executeCmd = fmt.Sprintf("%s --%s %s", executeCmd, unitArgs.Key, unitArgs.Value)
+		executeCmd = fmt.Sprintf("%s --%s=%s", executeCmd, unitArgs.Key, unitArgs.Value)
 	}
 
 	if timeout != "" {


### PR DESCRIPTION
Use the '=' instead of the space symbol to combine the network inject command, e.g. '--force=true' instead of '--force true'
