### PR TITLE
fix: jvm fault injection problem,className not match and javassist not found exception.

### DIFF
--- a/chaosmetad/tools/jvm/ChaosMetaClassFileTransformer.java
+++ b/chaosmetad/tools/jvm/ChaosMetaClassFileTransformer.java
@@ -64,6 +64,9 @@ public class ChaosMetaClassFileTransformer implements ClassFileTransformer {
         }
     }
 
+    private static String normalizeClass(String className) {
+        return className.replace("/", ".");
+    }
 
     public String getMessage() {
         return message;
@@ -80,11 +83,16 @@ public class ChaosMetaClassFileTransformer implements ClassFileTransformer {
         System.out.printf("transform class: %s, targetClassName: %s, status: %s, loader: %s, \n", className, targetClassName, status, loader.toString());
 
         try {
-            if (!targetClassName.equals(className) || (status.equals("recovered"))) {
+            //fix className not match
+            String normalizeClassName = normalizeClass(className);
+            if (!targetClassName.equals(normalizeClassName) || (status.equals("recovered"))) {
                 return null;
             }
 
             ClassPool pool = ClassPool.getDefault();
+            //fix javassist not found exception
+            ClassClassPath classPath = new ClassClassPath(loader.loadClass(targetClassName));
+            pool.insertClassPath(classPath);
             CtClass ctClass = pool.get(targetClassName);
             if (status.equals("success") || status.equals("fail")) {
                 // TODO: Need to consider how to clean up the added packages when restoring?


### PR DESCRIPTION
I found that when injecting faults into Java programs, the experiment did not take effect. I fixed 2 problems. One is the matching problem of class information, and the other is the problem that javassist cannot find the class information.